### PR TITLE
Seeding implementation for env, workers, backend (only burn for now).

### DIFF
--- a/crates/r2l-agents/src/on_policy_algorithms/mod.rs
+++ b/crates/r2l-agents/src/on_policy_algorithms/mod.rs
@@ -17,7 +17,7 @@ use derive_more::Deref;
 use r2l_core::{
     buffers::TrajectoryBatch,
     models::{Policy, ValueFunction},
-    rng::with_policy_rng,
+    rng::with_rng,
     tensor::R2lTensor,
 };
 use rand::seq::SliceRandom;
@@ -187,7 +187,7 @@ impl BatchIndexIterator {
                 (0..batch.len()).map(|j| (i, j)).collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
-        with_policy_rng(|rng| indices.shuffle(rng));
+        with_rng(|rng| indices.shuffle(rng));
         Self {
             indices,
             sample_size,

--- a/crates/r2l-agents/src/on_policy_algorithms/mod.rs
+++ b/crates/r2l-agents/src/on_policy_algorithms/mod.rs
@@ -17,7 +17,7 @@ use derive_more::Deref;
 use r2l_core::{
     buffers::TrajectoryBatch,
     models::{Policy, ValueFunction},
-    rng::RNG,
+    rng::with_policy_rng,
     tensor::R2lTensor,
 };
 use rand::seq::SliceRandom;
@@ -187,7 +187,7 @@ impl BatchIndexIterator {
                 (0..batch.len()).map(|j| (i, j)).collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
-        RNG.with_borrow_mut(|rng| indices.shuffle(rng));
+        with_policy_rng(|rng| indices.shuffle(rng));
         Self {
             indices,
             sample_size,

--- a/crates/r2l-api/src/builders/a2c/agent.rs
+++ b/crates/r2l-api/src/builders/a2c/agent.rs
@@ -1,5 +1,6 @@
 use std::sync::mpsc::Sender;
 
+use burn::prelude::Backend;
 use candle_core::Device;
 use candle_nn::ParamsAdamW;
 use r2l_agents::on_policy_algorithms::a2c::{A2C, A2CParams};
@@ -141,6 +142,10 @@ impl AgentBuilder for A2CAgentBuilder {
 
 impl AgentBuilder for A2CBurnAgentBuilder {
     type Agent = A2CBurnAgent<BurnBackend>;
+
+    fn seed(seed: u64) {
+        BurnBackend::seed(&Default::default(), seed);
+    }
 
     fn build(
         self,

--- a/crates/r2l-api/src/builders/a2c/agent.rs
+++ b/crates/r2l-api/src/builders/a2c/agent.rs
@@ -121,6 +121,10 @@ impl<Backend> OnPolicyAgentBuilder<A2CParams, DefaultA2CHookBuilder, Backend> {
 impl AgentBuilder for A2CAgentBuilder {
     type Agent = A2CCandleAgent;
 
+    fn seed(&self, seed: u64) {
+        self.backend.seed(seed);
+    }
+
     fn build(
         self,
         observation_size: usize,
@@ -143,7 +147,7 @@ impl AgentBuilder for A2CAgentBuilder {
 impl AgentBuilder for A2CBurnAgentBuilder {
     type Agent = A2CBurnAgent<BurnBackend>;
 
-    fn seed(seed: u64) {
+    fn seed(&self, seed: u64) {
         BurnBackend::seed(&Default::default(), seed);
     }
 

--- a/crates/r2l-api/src/builders/a2c/agent.rs
+++ b/crates/r2l-api/src/builders/a2c/agent.rs
@@ -32,7 +32,21 @@ pub type A2CCandleAgentBuilder = A2CAgentBuilder;
 pub type A2CBurnAgentBuilder =
     OnPolicyAgentBuilder<A2CParams, DefaultA2CHookBuilder, BuilderBurnBackend>;
 
+impl A2CBurnAgentBuilder {
+    fn seed(&self, seed: Option<u64>) {
+        if let Some(seed) = seed {
+            BurnBackend::seed(&Default::default(), seed);
+        }
+    }
+}
+
 impl A2CAgentBuilder {
+    fn seed(&self, seed: Option<u64>) {
+        if let Some(seed) = seed {
+            self.backend.seed(seed);
+        }
+    }
+
     /// Creates an A2C agent builder with default hyperparameters.
     pub fn new(n_envs: usize) -> Self {
         Self {
@@ -121,16 +135,14 @@ impl<Backend> OnPolicyAgentBuilder<A2CParams, DefaultA2CHookBuilder, Backend> {
 impl AgentBuilder for A2CAgentBuilder {
     type Agent = A2CCandleAgent;
 
-    fn seed(&self, seed: u64) {
-        self.backend.seed(seed);
-    }
-
     fn build(
         self,
         observation_size: usize,
         action_size: usize,
         action_space: ActionSpaceType,
+        seed: Option<u64>,
     ) -> anyhow::Result<Self::Agent> {
+        self.seed(seed);
         let device = self.backend.device.clone();
         let lm = self.learning_module_builder.build_candle(
             observation_size,
@@ -147,16 +159,14 @@ impl AgentBuilder for A2CAgentBuilder {
 impl AgentBuilder for A2CBurnAgentBuilder {
     type Agent = A2CBurnAgent<BurnBackend>;
 
-    fn seed(&self, seed: u64) {
-        BurnBackend::seed(&Default::default(), seed);
-    }
-
     fn build(
         self,
         observation_size: usize,
         action_size: usize,
         action_space: ActionSpaceType,
+        seed: Option<u64>,
     ) -> anyhow::Result<Self::Agent> {
+        self.seed(seed);
         let lm = self.learning_module_builder.build_burn::<BurnBackend>(
             observation_size,
             action_size,

--- a/crates/r2l-api/src/builders/a2c/algorithm.rs
+++ b/crates/r2l-api/src/builders/a2c/algorithm.rs
@@ -216,12 +216,14 @@ impl<EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST>
             learning_schedule,
             evaluator_builder,
             agent_builder,
+            seed,
         } = self;
         OnPolicyAlgorithmBuilder {
             sampler_builder,
             learning_schedule,
             evaluator_builder,
             agent_builder: agent_builder.with_candle(device),
+            seed,
         }
     }
 
@@ -232,12 +234,14 @@ impl<EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST>
             learning_schedule,
             evaluator_builder,
             agent_builder,
+            seed,
         } = self;
         OnPolicyAlgorithmBuilder {
             sampler_builder,
             learning_schedule,
             evaluator_builder,
             agent_builder: agent_builder.with_burn(),
+            seed,
         }
     }
 }
@@ -261,12 +265,14 @@ impl<EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST>
             learning_schedule,
             evaluator_builder,
             agent_builder,
+            seed,
         } = self;
         OnPolicyAlgorithmBuilder {
             sampler_builder,
             learning_schedule,
             evaluator_builder,
             agent_builder: agent_builder.with_candle(device),
+            seed,
         }
     }
 
@@ -277,12 +283,14 @@ impl<EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST>
             learning_schedule,
             evaluator_builder,
             agent_builder,
+            seed,
         } = self;
         OnPolicyAlgorithmBuilder {
             sampler_builder,
             learning_schedule,
             evaluator_builder,
             agent_builder: agent_builder.with_burn(),
+            seed,
         }
     }
 }

--- a/crates/r2l-api/src/builders/agent.rs
+++ b/crates/r2l-api/src/builders/agent.rs
@@ -14,6 +14,9 @@ pub trait AgentBuilder {
     /// Agent type produced by this builder.
     type Agent: Agent;
 
+    /// Seeds backend-specific random generators before the agent is built.
+    fn seed(_seed: u64) {}
+
     // TODO: This API is heavily in progress
     /// Builds the configured agent for the provided environment dimensions.
     fn build(

--- a/crates/r2l-api/src/builders/agent.rs
+++ b/crates/r2l-api/src/builders/agent.rs
@@ -14,9 +14,6 @@ pub trait AgentBuilder {
     /// Agent type produced by this builder.
     type Agent: Agent;
 
-    /// Seeds backend-specific random generators before the agent is built.
-    fn seed(&self, _seed: u64) {}
-
     // TODO: This API is heavily in progress
     /// Builds the configured agent for the provided environment dimensions.
     fn build(
@@ -24,6 +21,7 @@ pub trait AgentBuilder {
         observation_size: usize,
         action_size: usize,
         action_space: ActionSpaceType,
+        seed: Option<u64>,
     ) -> anyhow::Result<Self::Agent>;
 }
 

--- a/crates/r2l-api/src/builders/agent.rs
+++ b/crates/r2l-api/src/builders/agent.rs
@@ -15,7 +15,7 @@ pub trait AgentBuilder {
     type Agent: Agent;
 
     /// Seeds backend-specific random generators before the agent is built.
-    fn seed(_seed: u64) {}
+    fn seed(&self, _seed: u64) {}
 
     // TODO: This API is heavily in progress
     /// Builds the configured agent for the provided environment dimensions.
@@ -51,6 +51,14 @@ pub struct BurnBackend;
 #[derive(Debug, Clone)]
 pub struct CandleBackend {
     pub(crate) device: Device,
+}
+
+impl CandleBackend {
+    pub(crate) fn seed(&self, seed: u64) {
+        if !matches!(&self.device, Device::Cpu) {
+            self.device.set_seed(seed).unwrap();
+        }
+    }
 }
 
 impl<Params, HookBuilder, Backend> OnPolicyAgentBuilder<Params, HookBuilder, Backend> {

--- a/crates/r2l-api/src/builders/on_policy.rs
+++ b/crates/r2l-api/src/builders/on_policy.rs
@@ -3,7 +3,7 @@ use r2l_core::{
     on_policy::algorithm::{
         Agent, DefaultAdapter, OnPolicyAdapters, OnPolicyAlgorithm, OnPolicyRuntime,
     },
-    rng::{next_seed, set_seed},
+    rng::{sample_u64, set_seed},
     tensor::R2lTensor,
 };
 use r2l_sampler::{
@@ -282,7 +282,6 @@ impl<AB: AgentBuilder, EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>>
     {
         if let Some(seed) = self.seed {
             set_seed(seed);
-            self.agent_builder.seed(next_seed());
         }
         let env_description = self.sampler_builder.env_builder.env_description()?;
         let sampler = self.sampler_builder.build();
@@ -292,9 +291,9 @@ impl<AB: AgentBuilder, EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>>
             Space::Discrete(_) => ActionSpaceType::Discrete,
             Space::Continuous { .. } => ActionSpaceType::Continuous,
         };
-        let agent = self
-            .agent_builder
-            .build(observation_size, action_size, action_space)?;
+        let agent =
+            self.agent_builder
+                .build(observation_size, action_size, action_space, self.seed)?;
         let evaluator = self.evaluator_builder.map(|eb| eb.build());
         let hooks = DefaultOnPolicyAlgorithmHooks::new(self.learning_schedule, evaluator);
         Ok(OnPolicyAlgorithm {
@@ -322,6 +321,9 @@ impl<
                 R2lNormalizedSampler<<EB as EnvBuilder>::Env, SH::Target>,
             >,
     {
+        if let Some(seed) = self.seed {
+            set_seed(seed);
+        }
         let env_description = self.sampler_builder.env_builder.env_description()?;
         let observation_size = env_description.observation_size();
         let action_size = env_description.action_size();
@@ -331,9 +333,9 @@ impl<
         };
         let sampler = self.sampler_builder.build();
         let eval_obs_normalizer = sampler.obs_normalizer(NormalizerMode::ReadOnly);
-        let agent = self
-            .agent_builder
-            .build(observation_size, action_size, action_space)?;
+        let agent =
+            self.agent_builder
+                .build(observation_size, action_size, action_space, self.seed)?;
         let evaluator = self.evaluator_builder.map(|evaluator_builder| {
             let eval_sampler = R2lNormalizedSampler::build_with_obs_normalizer(
                 evaluator_builder.env_builder().clone(),

--- a/crates/r2l-api/src/builders/on_policy.rs
+++ b/crates/r2l-api/src/builders/on_policy.rs
@@ -3,8 +3,7 @@ use r2l_core::{
     on_policy::algorithm::{
         Agent, DefaultAdapter, OnPolicyAdapters, OnPolicyAlgorithm, OnPolicyRuntime,
     },
-    rng::{sample_u64, set_seed},
-    tensor::R2lTensor,
+    rng::set_seed,
 };
 use r2l_sampler::{
     NormalizedSamplerHook, NormalizerMode, R2lNormalizedSampler, R2lSampler, SamplerExecutionMode,

--- a/crates/r2l-api/src/builders/on_policy.rs
+++ b/crates/r2l-api/src/builders/on_policy.rs
@@ -280,7 +280,7 @@ impl<AB: AgentBuilder, EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>>
     {
         if let Some(seed) = self.seed {
             set_seed(seed);
-            AB::seed(seed);
+            self.agent_builder.seed(seed);
         }
         let env_description = self.sampler_builder.env_builder.env_description()?;
         let sampler = self.sampler_builder.build();

--- a/crates/r2l-api/src/builders/on_policy.rs
+++ b/crates/r2l-api/src/builders/on_policy.rs
@@ -244,12 +244,14 @@ impl<AB: AgentBuilder, EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST
             learning_schedule,
             evaluator_builder,
             agent_builder,
+            seed,
         } = self;
         OnPolicyAlgorithmBuilder {
             sampler_builder: sampler_builder.with_obs_normalizer(obs_clip),
             learning_schedule,
             evaluator_builder,
             agent_builder,
+            seed,
         }
     }
 }

--- a/crates/r2l-api/src/builders/on_policy.rs
+++ b/crates/r2l-api/src/builders/on_policy.rs
@@ -3,6 +3,8 @@ use r2l_core::{
     on_policy::algorithm::{
         Agent, DefaultAdapter, OnPolicyAdapters, OnPolicyAlgorithm, OnPolicyRuntime,
     },
+    rng::set_seed,
+    tensor::R2lTensor,
 };
 use r2l_sampler::{
     NormalizedSamplerHook, NormalizerMode, R2lNormalizedSampler, R2lSampler, SamplerExecutionMode,
@@ -73,6 +75,7 @@ pub struct OnPolicyAlgorithmBuilder<
     pub(crate) learning_schedule: LearningSchedule,
     pub(crate) evaluator_builder: Option<BestActorEvaluatorBuilder<EB>>,
     pub(crate) agent_builder: AB,
+    pub(crate) seed: Option<u64>,
 }
 
 impl<AB: AgentBuilder, EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST>
@@ -86,6 +89,7 @@ impl<AB: AgentBuilder, EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST
             agent_builder,
             evaluator_builder: None,
             learning_schedule: LearningSchedule::rollout_bound(300),
+            seed: None,
         }
     }
 
@@ -99,12 +103,14 @@ impl<AB: AgentBuilder, EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST
             agent_builder,
             learning_schedule,
             evaluator_builder,
+            seed,
         } = self;
         OnPolicyAlgorithmBuilder {
             sampler_builder: sampler_builder.with_hook(hook_builder),
             agent_builder,
             evaluator_builder,
             learning_schedule,
+            seed,
         }
     }
 
@@ -119,12 +125,14 @@ impl<AB: AgentBuilder, EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST
             agent_builder,
             learning_schedule,
             evaluator_builder,
+            seed,
         } = self;
         OnPolicyAlgorithmBuilder {
             sampler_builder: sampler_builder.with_hook(rollout_bound),
             agent_builder,
             evaluator_builder,
             learning_schedule,
+            seed,
         }
     }
 
@@ -140,6 +148,12 @@ impl<AB: AgentBuilder, EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST
     /// Replaces the learning schedule that controls training termination.
     pub fn with_learning_schedule(mut self, learning_schedule: LearningSchedule) -> Self {
         self.learning_schedule = learning_schedule;
+        self
+    }
+
+    /// Sets the seed used by r2l, Gym reset seeds, and backend-specific RNGs.
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
         self
     }
 
@@ -264,6 +278,10 @@ impl<AB: AgentBuilder, EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>>
                 R2lSampler<<EB as EnvBuilder>::Env, SH::Target>,
             >,
     {
+        if let Some(seed) = self.seed {
+            set_seed(seed);
+            AB::seed(seed);
+        }
         let env_description = self.sampler_builder.env_builder.env_description()?;
         let sampler = self.sampler_builder.build();
         let observation_size = env_description.observation_size();

--- a/crates/r2l-api/src/builders/on_policy.rs
+++ b/crates/r2l-api/src/builders/on_policy.rs
@@ -3,7 +3,7 @@ use r2l_core::{
     on_policy::algorithm::{
         Agent, DefaultAdapter, OnPolicyAdapters, OnPolicyAlgorithm, OnPolicyRuntime,
     },
-    rng::set_seed,
+    rng::{next_seed, set_seed},
     tensor::R2lTensor,
 };
 use r2l_sampler::{
@@ -282,7 +282,7 @@ impl<AB: AgentBuilder, EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>>
     {
         if let Some(seed) = self.seed {
             set_seed(seed);
-            self.agent_builder.seed(seed);
+            self.agent_builder.seed(next_seed());
         }
         let env_description = self.sampler_builder.env_builder.env_description()?;
         let sampler = self.sampler_builder.build();

--- a/crates/r2l-api/src/builders/ppo/agent.rs
+++ b/crates/r2l-api/src/builders/ppo/agent.rs
@@ -133,6 +133,10 @@ impl<Backend> OnPolicyAgentBuilder<PPOParams, DefaultPPOHookBuilder, Backend> {
 impl AgentBuilder for PPOAgentBuilder {
     type Agent = PPOCandleAgent;
 
+    fn seed(&self, seed: u64) {
+        self.backend.seed(seed);
+    }
+
     fn build(
         self,
         observation_size: usize,
@@ -155,7 +159,7 @@ impl AgentBuilder for PPOAgentBuilder {
 impl AgentBuilder for PPOBurnAgentBuilder {
     type Agent = PPOBurnAgent<BurnBackend>;
 
-    fn seed(seed: u64) {
+    fn seed(&self, seed: u64) {
         BurnBackend::seed(&Default::default(), seed);
     }
 

--- a/crates/r2l-api/src/builders/ppo/agent.rs
+++ b/crates/r2l-api/src/builders/ppo/agent.rs
@@ -32,7 +32,21 @@ pub type PPOCandleAgentBuilder = PPOAgentBuilder;
 pub type PPOBurnAgentBuilder =
     OnPolicyAgentBuilder<PPOParams, DefaultPPOHookBuilder, BuilderBurnBackend>;
 
+impl PPOBurnAgentBuilder {
+    fn seed(&self, seed: Option<u64>) {
+        if let Some(seed) = seed {
+            BurnBackend::seed(&Default::default(), seed);
+        }
+    }
+}
+
 impl PPOAgentBuilder {
+    fn seed(&self, seed: Option<u64>) {
+        if let Some(seed) = seed {
+            BurnBackend::seed(&Default::default(), seed);
+        }
+    }
+
     /// Creates a PPO agent builder with default hyperparameters.
     pub fn new(n_envs: usize) -> Self {
         Self {
@@ -133,16 +147,14 @@ impl<Backend> OnPolicyAgentBuilder<PPOParams, DefaultPPOHookBuilder, Backend> {
 impl AgentBuilder for PPOAgentBuilder {
     type Agent = PPOCandleAgent;
 
-    fn seed(&self, seed: u64) {
-        self.backend.seed(seed);
-    }
-
     fn build(
         self,
         observation_size: usize,
         action_size: usize,
         action_space: ActionSpaceType,
+        seed: Option<u64>,
     ) -> anyhow::Result<Self::Agent> {
+        self.seed(seed);
         let device = self.backend.device.clone();
         let lm = self.learning_module_builder.build_candle(
             observation_size,
@@ -159,16 +171,14 @@ impl AgentBuilder for PPOAgentBuilder {
 impl AgentBuilder for PPOBurnAgentBuilder {
     type Agent = PPOBurnAgent<BurnBackend>;
 
-    fn seed(&self, seed: u64) {
-        BurnBackend::seed(&Default::default(), seed);
-    }
-
     fn build(
         self,
         observation_size: usize,
         action_size: usize,
         action_space: ActionSpaceType,
+        seed: Option<u64>,
     ) -> anyhow::Result<Self::Agent> {
+        self.seed(seed);
         let lm = self.learning_module_builder.build_burn::<BurnBackend>(
             observation_size,
             action_size,

--- a/crates/r2l-api/src/builders/ppo/agent.rs
+++ b/crates/r2l-api/src/builders/ppo/agent.rs
@@ -1,5 +1,6 @@
 use std::sync::mpsc::Sender;
 
+use burn::prelude::Backend;
 use candle_core::Device;
 use candle_nn::ParamsAdamW;
 use r2l_agents::on_policy_algorithms::ppo::{PPO, PPOParams};
@@ -153,6 +154,10 @@ impl AgentBuilder for PPOAgentBuilder {
 
 impl AgentBuilder for PPOBurnAgentBuilder {
     type Agent = PPOBurnAgent<BurnBackend>;
+
+    fn seed(seed: u64) {
+        BurnBackend::seed(&Default::default(), seed);
+    }
 
     fn build(
         self,

--- a/crates/r2l-api/src/builders/ppo/algorithm.rs
+++ b/crates/r2l-api/src/builders/ppo/algorithm.rs
@@ -242,12 +242,14 @@ impl<EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST>
             learning_schedule,
             evaluator_builder,
             agent_builder,
+            seed,
         } = self;
         OnPolicyAlgorithmBuilder {
             sampler_builder,
             learning_schedule,
             evaluator_builder,
             agent_builder: agent_builder.with_candle(device),
+            seed,
         }
     }
 
@@ -258,12 +260,14 @@ impl<EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST>
             learning_schedule,
             evaluator_builder,
             agent_builder,
+            seed,
         } = self;
         OnPolicyAlgorithmBuilder {
             sampler_builder,
             learning_schedule,
             evaluator_builder,
             agent_builder: agent_builder.with_burn(),
+            seed,
         }
     }
 }
@@ -287,12 +291,14 @@ impl<EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST>
             learning_schedule,
             evaluator_builder,
             agent_builder,
+            seed,
         } = self;
         OnPolicyAlgorithmBuilder {
             sampler_builder,
             learning_schedule,
             evaluator_builder,
             agent_builder: agent_builder.with_candle(device),
+            seed,
         }
     }
 
@@ -303,12 +309,14 @@ impl<EB: EnvBuilder, SH: SamplerHookBuilder<Env = EB::Env>, ST>
             learning_schedule,
             evaluator_builder,
             agent_builder,
+            seed,
         } = self;
         OnPolicyAlgorithmBuilder {
             sampler_builder,
             learning_schedule,
             evaluator_builder,
             agent_builder: agent_builder.with_burn(),
+            seed,
         }
     }
 }

--- a/crates/r2l-api/src/builders/sampler.rs
+++ b/crates/r2l-api/src/builders/sampler.rs
@@ -52,8 +52,8 @@ impl<E: Env<Tensor: R2lTensor>> SamplerHookBuilder for StepHookBound<E> {
     type Target = StepBoundHook<Self::Env>;
 
     fn build(self) -> Self::Target {
-        let hook = StepBoundHook::new(self.n_step);
-        hook
+        
+        StepBoundHook::new(self.n_step)
     }
 }
 

--- a/crates/r2l-api/src/evaluators/best_actor_evaluator.rs
+++ b/crates/r2l-api/src/evaluators/best_actor_evaluator.rs
@@ -36,7 +36,7 @@ impl<EB: EnvBuilder> BestActorEvaluatorBuilder<EB> {
     pub fn new(env_builder: EB) -> Self {
         Self {
             evaluator_frequency: 1,
-            env_builder: EnvBuilderType::homogenous(env_builder.into(), 10),
+            env_builder: EnvBuilderType::homogenous(env_builder, 10),
             n_episodes: 5,
             execution_mode: SamplerExecutionMode::Thread,
             eval_path: None,
@@ -157,7 +157,7 @@ impl<A: Actor, ES: Sampler> BestActorEvaluator<A, ES> {
         rt: &mut OnPolicyRuntime<AG, TS, C>,
     ) {
         self.current_evaluator_step += 1;
-        if self.current_evaluator_step % self.evaluator_frequency == 0 {
+        if self.current_evaluator_step.is_multiple_of(self.evaluator_frequency) {
             let actor = rt.actor();
             let adapted_actor = rt.adapted_actor();
             self.eval_adapted(adapted_actor, actor);

--- a/crates/r2l-api/src/hooks/on_policy.rs
+++ b/crates/r2l-api/src/hooks/on_policy.rs
@@ -4,15 +4,14 @@ use anyhow::Result;
 use r2l_core::{
     HookResult,
     buffers::TrajectoryBatch,
-    env::{Env, EnvBuilder},
+    env::Env,
     on_policy::algorithm::{
         Agent, OnPolicyAdapters, OnPolicyAlgorithmHooks, OnPolicyRuntime, Sampler,
     },
     tensor::R2lTensor,
 };
-use r2l_sampler::{R2lNormalizedSampler, R2lSampler};
 
-use crate::{BestActorEvaluator, BestActorEvaluatorBuilder, hooks::sampler::EpisodeBoundHook};
+use crate::BestActorEvaluator;
 
 /// Training-stop policy for [`DefaultOnPolicyAlgorithmHooks`].
 ///

--- a/crates/r2l-burn/src/distributions/categorical_distribution.rs
+++ b/crates/r2l-burn/src/distributions/categorical_distribution.rs
@@ -10,7 +10,7 @@ use burn::{
 use burn_store::{ModuleSnapshot, ModuleStore, SafetensorsStore};
 use r2l_core::{
     models::{ActivationFunction, Actor, Policy},
-    rng::with_policy_rng,
+    rng::with_rng,
 };
 use rand::distr::Distribution as RandDistributiion;
 use rand::distr::weighted::WeightedIndex;
@@ -60,7 +60,7 @@ impl<B: Backend> Actor for CategoricalDistribution<B> {
         let logits = self.logits.forward(observation);
         let action_probs: Vec<f32> = softmax(logits, 1).to_data().to_vec().unwrap();
         let distribution = WeightedIndex::new(&action_probs).unwrap();
-        let action = with_policy_rng(|rng| distribution.sample(rng));
+        let action = with_rng(|rng| distribution.sample(rng));
         let mut action_mask: Vec<f32> = vec![0.0; self.action_size];
         action_mask[action] = 1.;
         Ok(Tensor::from_data(

--- a/crates/r2l-burn/src/distributions/categorical_distribution.rs
+++ b/crates/r2l-burn/src/distributions/categorical_distribution.rs
@@ -8,7 +8,10 @@ use burn::{
     },
 };
 use burn_store::{ModuleSnapshot, ModuleStore, SafetensorsStore};
-use r2l_core::models::{ActivationFunction, Actor, Policy};
+use r2l_core::{
+    models::{ActivationFunction, Actor, Policy},
+    rng::with_policy_rng,
+};
 use rand::distr::Distribution as RandDistributiion;
 use rand::distr::weighted::WeightedIndex;
 
@@ -57,7 +60,7 @@ impl<B: Backend> Actor for CategoricalDistribution<B> {
         let logits = self.logits.forward(observation);
         let action_probs: Vec<f32> = softmax(logits, 1).to_data().to_vec().unwrap();
         let distribution = WeightedIndex::new(&action_probs).unwrap();
-        let action = distribution.sample(&mut rand::rng());
+        let action = with_policy_rng(|rng| distribution.sample(rng));
         let mut action_mask: Vec<f32> = vec![0.0; self.action_size];
         action_mask[action] = 1.;
         Ok(Tensor::from_data(

--- a/crates/r2l-burn/src/distributions/recurrent_categorical_distribution.rs
+++ b/crates/r2l-burn/src/distributions/recurrent_categorical_distribution.rs
@@ -11,7 +11,7 @@ use burn::{
 use burn_store::{ModuleSnapshot, ModuleStore, SafetensorsStore};
 use r2l_core::{
     models::{ActivationFunction, Actor, Policy},
-    rng::with_policy_rng,
+    rng::with_rng,
 };
 use rand::distr::Distribution as RandDistribution;
 use rand::distr::weighted::WeightedIndex;
@@ -107,7 +107,7 @@ impl<B: Backend> Actor for RecurrentCategoricalDistribution<B> {
         let logits = self.logits(observation);
         let action_probs: Vec<f32> = softmax(logits, 1).to_data().to_vec().unwrap();
         let distribution = WeightedIndex::new(&action_probs).unwrap();
-        let action = with_policy_rng(|rng| distribution.sample(rng));
+        let action = with_rng(|rng| distribution.sample(rng));
         let mut action_mask: Vec<f32> = vec![0.0; self.action_size];
         action_mask[action] = 1.;
         Ok(Tensor::from_data(

--- a/crates/r2l-burn/src/distributions/recurrent_categorical_distribution.rs
+++ b/crates/r2l-burn/src/distributions/recurrent_categorical_distribution.rs
@@ -9,7 +9,10 @@ use burn::{
     },
 };
 use burn_store::{ModuleSnapshot, ModuleStore, SafetensorsStore};
-use r2l_core::models::{ActivationFunction, Actor, Policy};
+use r2l_core::{
+    models::{ActivationFunction, Actor, Policy},
+    rng::with_policy_rng,
+};
 use rand::distr::Distribution as RandDistribution;
 use rand::distr::weighted::WeightedIndex;
 
@@ -104,7 +107,7 @@ impl<B: Backend> Actor for RecurrentCategoricalDistribution<B> {
         let logits = self.logits(observation);
         let action_probs: Vec<f32> = softmax(logits, 1).to_data().to_vec().unwrap();
         let distribution = WeightedIndex::new(&action_probs).unwrap();
-        let action = distribution.sample(&mut rand::rng());
+        let action = with_policy_rng(|rng| distribution.sample(rng));
         let mut action_mask: Vec<f32> = vec![0.0; self.action_size];
         action_mask[action] = 1.;
         Ok(Tensor::from_data(

--- a/crates/r2l-candle/src/distributions/categorical_distribution.rs
+++ b/crates/r2l-candle/src/distributions/categorical_distribution.rs
@@ -7,7 +7,7 @@ use candle_nn::ops::log_softmax;
 use candle_nn::{Module, ops::softmax};
 use r2l_core::{
     models::{ActivationFunction, Actor, Policy, PolicyMetadata},
-    rng::with_policy_rng,
+    rng::with_rng,
 };
 use rand::distr::Distribution as RandDistributiion;
 use rand::distr::weighted::WeightedIndex;
@@ -89,7 +89,7 @@ impl Actor for CategoricalDistribution {
         let logits = self.logits.forward(&observation)?;
         let action_probs: Vec<f32> = softmax(&logits, 1)?.squeeze(0)?.to_vec1()?;
         let distribution = WeightedIndex::new(&action_probs).map_err(Error::wrap)?;
-        let action = with_policy_rng(|rng| distribution.sample(rng));
+        let action = with_rng(|rng| distribution.sample(rng));
         // TODO: there is a one_hot function in candle. Should we use it?
         let mut action_mask: Vec<f32> = vec![0.0; self.action_size];
         action_mask[action] = 1.;

--- a/crates/r2l-candle/src/distributions/categorical_distribution.rs
+++ b/crates/r2l-candle/src/distributions/categorical_distribution.rs
@@ -5,7 +5,10 @@ use candle_core::{DType, Device, Error, Tensor};
 use candle_nn::VarBuilder;
 use candle_nn::ops::log_softmax;
 use candle_nn::{Module, ops::softmax};
-use r2l_core::models::{ActivationFunction, Actor, Policy, PolicyMetadata};
+use r2l_core::{
+    models::{ActivationFunction, Actor, Policy, PolicyMetadata},
+    rng::with_policy_rng,
+};
 use rand::distr::Distribution as RandDistributiion;
 use rand::distr::weighted::WeightedIndex;
 use safetensors::serialize as st_serialize;
@@ -86,7 +89,7 @@ impl Actor for CategoricalDistribution {
         let logits = self.logits.forward(&observation)?;
         let action_probs: Vec<f32> = softmax(&logits, 1)?.squeeze(0)?.to_vec1()?;
         let distribution = WeightedIndex::new(&action_probs).map_err(Error::wrap)?;
-        let action = distribution.sample(&mut rand::rng());
+        let action = with_policy_rng(|rng| distribution.sample(rng));
         // TODO: there is a one_hot function in candle. Should we use it?
         let mut action_mask: Vec<f32> = vec![0.0; self.action_size];
         action_mask[action] = 1.;

--- a/crates/r2l-core/src/rng.rs
+++ b/crates/r2l-core/src/rng.rs
@@ -10,11 +10,11 @@ pub fn set_seed(seed: u64) {
     RNG.with_borrow_mut(|rng| *rng = StdRng::seed_from_u64(seed));
 }
 
-pub fn next_seed() -> u64 {
+pub fn sample_u64() -> u64 {
     RNG.with_borrow_mut(|rng| rng.random::<u64>())
 }
 
 /// Runs a closure with the policy/action-sampling random stream.
-pub fn with_policy_rng<T>(f: impl FnOnce(&mut StdRng) -> T) -> T {
+pub fn with_rng<T>(f: impl FnOnce(&mut StdRng) -> T) -> T {
     RNG.with_borrow_mut(f)
 }

--- a/crates/r2l-core/src/rng.rs
+++ b/crates/r2l-core/src/rng.rs
@@ -1,32 +1,20 @@
-use std::{
-    cell::RefCell,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use std::cell::RefCell;
 
 use rand::{RngExt, SeedableRng, rngs::StdRng};
 
-static RNG_SEED: AtomicU64 = AtomicU64::new(0);
-
 thread_local! {
-    static RNG: RefCell<StdRng> = RefCell::new(env_rng(0));
+    static RNG: RefCell<StdRng> = RefCell::new(StdRng::seed_from_u64(0));
 }
 
 pub fn set_seed(seed: u64) {
-    RNG_SEED.store(seed, Ordering::Relaxed);
-    RNG.with_borrow_mut(|rng| *rng = env_rng(0));
+    RNG.with_borrow_mut(|rng| *rng = StdRng::seed_from_u64(seed));
 }
 
-/// Generates a deterministic seed for an environment reset.
-pub fn env_seed() -> u64 {
+pub fn next_seed() -> u64 {
     RNG.with_borrow_mut(|rng| rng.random::<u64>())
 }
 
 /// Runs a closure with the policy/action-sampling random stream.
 pub fn with_policy_rng<T>(f: impl FnOnce(&mut StdRng) -> T) -> T {
     RNG.with_borrow_mut(f)
-}
-
-pub fn env_rng(stream_id: usize) -> StdRng {
-    let seed = RNG_SEED.load(Ordering::Relaxed);
-    StdRng::seed_from_u64(seed.wrapping_add(stream_id as u64))
 }

--- a/crates/r2l-core/src/rng.rs
+++ b/crates/r2l-core/src/rng.rs
@@ -7,51 +7,26 @@ use rand::{RngExt, SeedableRng, rngs::StdRng};
 
 static RNG_SEED: AtomicU64 = AtomicU64::new(0);
 
-const ENV_STREAM: u64 = 0x9e37_79b9_7f4a_7c15;
-const POLICY_STREAM: u64 = 0xbf58_476d_1ce4_e5b9;
-
 thread_local! {
-    static ENV_RNG: RefCell<StdRng> = RefCell::new(env_rng(0));
-    static POLICY_RNG: RefCell<StdRng> = RefCell::new(policy_rng());
+    static RNG: RefCell<StdRng> = RefCell::new(env_rng(0));
 }
 
 pub fn set_seed(seed: u64) {
     RNG_SEED.store(seed, Ordering::Relaxed);
-    ENV_RNG.with_borrow_mut(|rng| *rng = env_rng(0));
-    POLICY_RNG.with_borrow_mut(|rng| *rng = policy_rng());
+    RNG.with_borrow_mut(|rng| *rng = env_rng(0));
 }
 
 /// Generates a deterministic seed for an environment reset.
 pub fn env_seed() -> u64 {
-    ENV_RNG.with_borrow_mut(|rng| rng.random::<u64>())
-}
-
-/// Creates a deterministic environment-reset RNG for one sampler worker.
-pub fn env_worker_rng(worker_idx: usize) -> StdRng {
-    env_rng(worker_idx + 1)
+    RNG.with_borrow_mut(|rng| rng.random::<u64>())
 }
 
 /// Runs a closure with the policy/action-sampling random stream.
 pub fn with_policy_rng<T>(f: impl FnOnce(&mut StdRng) -> T) -> T {
-    POLICY_RNG.with_borrow_mut(f)
+    RNG.with_borrow_mut(f)
 }
 
-fn env_rng(stream_id: usize) -> StdRng {
-    StdRng::seed_from_u64(stream_seed(ENV_STREAM, stream_id as u64))
-}
-
-fn policy_rng() -> StdRng {
-    StdRng::seed_from_u64(stream_seed(POLICY_STREAM, 0))
-}
-
-fn stream_seed(stream: u64, stream_id: u64) -> u64 {
+pub fn env_rng(stream_id: usize) -> StdRng {
     let seed = RNG_SEED.load(Ordering::Relaxed);
-    splitmix64(seed ^ stream ^ stream_id.wrapping_mul(0xd2b7_4407_b1ce_6e93))
-}
-
-fn splitmix64(mut x: u64) -> u64 {
-    x = x.wrapping_add(0x9e37_79b9_7f4a_7c15);
-    x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
-    x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
-    x ^ (x >> 31)
+    StdRng::seed_from_u64(seed.wrapping_add(stream_id as u64))
 }

--- a/crates/r2l-core/src/rng.rs
+++ b/crates/r2l-core/src/rng.rs
@@ -1,7 +1,57 @@
-use std::cell::RefCell;
+use std::{
+    cell::RefCell,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
-use rand::{SeedableRng, rngs::StdRng};
+use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+static RNG_SEED: AtomicU64 = AtomicU64::new(0);
+
+const ENV_STREAM: u64 = 0x9e37_79b9_7f4a_7c15;
+const POLICY_STREAM: u64 = 0xbf58_476d_1ce4_e5b9;
 
 thread_local! {
-    pub static RNG: RefCell<StdRng> = RefCell::new(StdRng::seed_from_u64(0));
+    static ENV_RNG: RefCell<StdRng> = RefCell::new(env_rng(0));
+    static POLICY_RNG: RefCell<StdRng> = RefCell::new(policy_rng());
+}
+
+pub fn set_seed(seed: u64) {
+    RNG_SEED.store(seed, Ordering::Relaxed);
+    ENV_RNG.with_borrow_mut(|rng| *rng = env_rng(0));
+    POLICY_RNG.with_borrow_mut(|rng| *rng = policy_rng());
+}
+
+/// Generates a deterministic seed for an environment reset.
+pub fn env_seed() -> u64 {
+    ENV_RNG.with_borrow_mut(|rng| rng.random::<u64>())
+}
+
+/// Creates a deterministic environment-reset RNG for one sampler worker.
+pub fn env_worker_rng(worker_idx: usize) -> StdRng {
+    env_rng(worker_idx + 1)
+}
+
+/// Runs a closure with the policy/action-sampling random stream.
+pub fn with_policy_rng<T>(f: impl FnOnce(&mut StdRng) -> T) -> T {
+    POLICY_RNG.with_borrow_mut(f)
+}
+
+fn env_rng(stream_id: usize) -> StdRng {
+    StdRng::seed_from_u64(stream_seed(ENV_STREAM, stream_id as u64))
+}
+
+fn policy_rng() -> StdRng {
+    StdRng::seed_from_u64(stream_seed(POLICY_STREAM, 0))
+}
+
+fn stream_seed(stream: u64, stream_id: u64) -> u64 {
+    let seed = RNG_SEED.load(Ordering::Relaxed);
+    splitmix64(seed ^ stream ^ stream_id.wrapping_mul(0xd2b7_4407_b1ce_6e93))
+}
+
+fn splitmix64(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    x ^ (x >> 31)
 }

--- a/crates/r2l-core/src/running_mean.rs
+++ b/crates/r2l-core/src/running_mean.rs
@@ -62,8 +62,8 @@ impl<T: R2lTensor> RunningMeanStd<T> {
         let mean_size = self.mean.size();
         assert!(t.iter().all(|t| t.len() == mean_size));
         let t = t
-            .into_iter()
-            .map(|t| T::from_slice_and_shape(&t, self.mean.to_shape()))
+            .iter()
+            .map(|t| T::from_slice_and_shape(t, self.mean.to_shape()))
             .collect::<Vec<_>>();
         self.update(&t);
     }

--- a/crates/r2l-core/src/tensor/mod.rs
+++ b/crates/r2l-core/src/tensor/mod.rs
@@ -88,7 +88,7 @@ pub trait R2lTensor: Clone + Send + Sync + Debug + 'static {
     fn mul_scalar(&self, scalar: f32) -> anyhow::Result<Self>;
 
     fn add_multiple(tensors: &[Self]) -> Self {
-        assert!(tensors.len() > 0);
+        assert!(!tensors.is_empty());
         let shape = tensors[0].to_shape();
         let init = Self::zeros(shape);
         tensors
@@ -98,7 +98,7 @@ pub trait R2lTensor: Clone + Send + Sync + Debug + 'static {
 
     /// Calculates the mean of the tensors.
     fn mean_tensors(tensors: &[Self]) -> Self {
-        assert!(tensors.len() > 0);
+        assert!(!tensors.is_empty());
         let sum = Self::add_multiple(tensors);
         sum.mul_scalar(1f32 / tensors.len() as f32).unwrap()
     }

--- a/crates/r2l-examples/examples/a2c/main.rs
+++ b/crates/r2l-examples/examples/a2c/main.rs
@@ -15,6 +15,7 @@ fn main() {
     let a2c_builder = A2CAlgorithmBuilder::gym("Pendulum-v1", 10)
         .with_candle(Device::Cpu)
         .with_burn()
+        .with_seed(0)
         .with_entropy_coeff(0.2)
         .with_gradient_clipping(Some(0.5))
         .with_rollout_bound(StepHookBound::new(2048))

--- a/crates/r2l-examples/examples/ppo/main.rs
+++ b/crates/r2l-examples/examples/ppo/main.rs
@@ -15,6 +15,7 @@ fn main() {
     let hidden_layers = vec![64, 64];
     let ppo_builder = PPOAlgorithmBuilder::gym(ENV_NAME, 10)
         .with_burn()
+        .with_seed(0)
         .with_policy_hidden_layers(hidden_layers.clone())
         .with_clip_range(0.2)
         .with_entropy_coeff(0.)

--- a/crates/r2l-examples/examples/r2l-gui/main.rs
+++ b/crates/r2l-examples/examples/r2l-gui/main.rs
@@ -119,6 +119,7 @@ pub fn train_ppo(
     // TODO: The generic here is ugly
     let ppo_builder = PPOAlgorithmBuilder::gym(ENV_NAME, 10)
         .with_burn()
+        .with_seed(0)
         .with_entropy_coeff(ENT_COEFF)
         .with_gradient_clipping(Some(MAX_GRAD_NORM))
         .with_target_kl(Some(TARGET_KL))

--- a/crates/r2l-sampler/src/direct/mod.rs
+++ b/crates/r2l-sampler/src/direct/mod.rs
@@ -14,6 +14,7 @@ use r2l_core::env::EnvBuilder;
 use r2l_core::env::EnvBuilderType;
 use r2l_core::models::Actor;
 use r2l_core::on_policy::algorithm::Sampler;
+use r2l_core::rng::{next_seed, set_seed};
 
 use crate::RolloutMode;
 use crate::SamplerExecutionMode;
@@ -58,7 +59,7 @@ impl<E: Env> R2lSamplerCore<E> {
                     .enumerate()
                     .map(|(idx, element_handle)| {
                         let env = env_builder.build_idx(idx).unwrap(); // TODO: for now
-                        Worker::new(env, element_handle, idx)
+                        Worker::new(env, element_handle)
                     })
                     .collect();
                 WorkerPool::Vec(workers)
@@ -72,9 +73,11 @@ impl<E: Env> R2lSamplerCore<E> {
                         let (command_tx, command_rx) = crossbeam::channel::unbounded();
                         let (res_tx, res_rx) = crossbeam::channel::unbounded();
                         let env_builder = env_builder.clone();
+                        let worker_seed = next_seed();
                         let handle = std::thread::spawn(move || {
+                            set_seed(worker_seed);
                             let env = env_builder.build_idx(idx).unwrap();
-                            let worker = Worker::new(env, element_handle, idx);
+                            let worker = Worker::new(env, element_handle);
                             let mut thread_worker = ThreadWorker::new(worker, command_rx, res_tx);
                             thread_worker.work();
                         });

--- a/crates/r2l-sampler/src/direct/mod.rs
+++ b/crates/r2l-sampler/src/direct/mod.rs
@@ -58,7 +58,7 @@ impl<E: Env> R2lSamplerCore<E> {
                     .enumerate()
                     .map(|(idx, element_handle)| {
                         let env = env_builder.build_idx(idx).unwrap(); // TODO: for now
-                        Worker::new(env, element_handle)
+                        Worker::new(env, element_handle, idx)
                     })
                     .collect();
                 WorkerPool::Vec(workers)
@@ -74,7 +74,7 @@ impl<E: Env> R2lSamplerCore<E> {
                         let env_builder = env_builder.clone();
                         let handle = std::thread::spawn(move || {
                             let env = env_builder.build_idx(idx).unwrap();
-                            let worker = Worker::new(env, element_handle);
+                            let worker = Worker::new(env, element_handle, idx);
                             let mut thread_worker = ThreadWorker::new(worker, command_rx, res_tx);
                             thread_worker.work();
                         });

--- a/crates/r2l-sampler/src/direct/mod.rs
+++ b/crates/r2l-sampler/src/direct/mod.rs
@@ -14,7 +14,7 @@ use r2l_core::env::EnvBuilder;
 use r2l_core::env::EnvBuilderType;
 use r2l_core::models::Actor;
 use r2l_core::on_policy::algorithm::Sampler;
-use r2l_core::rng::{next_seed, set_seed};
+use r2l_core::rng::{sample_u64, set_seed};
 
 use crate::RolloutMode;
 use crate::SamplerExecutionMode;
@@ -73,7 +73,7 @@ impl<E: Env> R2lSamplerCore<E> {
                         let (command_tx, command_rx) = crossbeam::channel::unbounded();
                         let (res_tx, res_rx) = crossbeam::channel::unbounded();
                         let env_builder = env_builder.clone();
-                        let worker_seed = next_seed();
+                        let worker_seed = sample_u64();
                         let handle = std::thread::spawn(move || {
                             set_seed(worker_seed);
                             let env = env_builder.build_idx(idx).unwrap();

--- a/crates/r2l-sampler/src/direct/worker.rs
+++ b/crates/r2l-sampler/src/direct/worker.rs
@@ -6,7 +6,7 @@ use r2l_core::{
     buffers::{Memory, buffer::TrajectoryBuffer},
     env::{Env, EnvDescription, Snapshot},
     models::Actor,
-    rng::next_seed,
+    rng::sample_u64,
     tensor::R2lTensor,
 };
 
@@ -26,7 +26,7 @@ pub fn step_env<T: R2lTensor, E: Env<Tensor = T>>(
     let state = if let Some(state) = last_state {
         state
     } else {
-        env.reset(next_seed()).unwrap()
+        env.reset(sample_u64()).unwrap()
     };
     let action = actor.action(state.clone()).unwrap();
     let Snapshot {
@@ -37,7 +37,7 @@ pub fn step_env<T: R2lTensor, E: Env<Tensor = T>>(
     } = env.step(action.clone()).unwrap();
     let done = terminated || truncated;
     if done {
-        next_state = env.reset(next_seed()).unwrap();
+        next_state = env.reset(sample_u64()).unwrap();
     }
     Memory {
         state,
@@ -298,7 +298,7 @@ impl<T: R2lTensor> ThreadWorkers<T> {
 
     pub fn reset_all(&self) {
         for worker_handle in self.worker_handles.iter() {
-            worker_handle.send(WorkerCommand::ResetEnv(next_seed()));
+            worker_handle.send(WorkerCommand::ResetEnv(sample_u64()));
         }
         for worker_handle in self.worker_handles.iter() {
             worker_handle.recv();
@@ -331,7 +331,7 @@ impl<T: R2lTensor> ThreadWorkers<T> {
 
     pub fn reset_envs_uninserted(&self) -> Vec<T> {
         for worker_handle in self.worker_handles.iter() {
-            worker_handle.send(WorkerCommand::ResetEnvUninserted(next_seed()));
+            worker_handle.send(WorkerCommand::ResetEnvUninserted(sample_u64()));
         }
         self.worker_handles
             .iter()
@@ -439,7 +439,7 @@ impl<E: Env> WorkerPool<E> {
         match self {
             Self::Vec(workers) => {
                 for worker in workers {
-                    worker.reset(next_seed());
+                    worker.reset(sample_u64());
                 }
             }
             Self::Thread(workers) => {
@@ -491,7 +491,7 @@ impl<E: Env> WorkerPool<E> {
                 // resets all the envs but does not set it as a last state
                 workers
                     .iter_mut()
-                    .map(|w| w.reset_env_uninserted(next_seed()))
+                    .map(|w| w.reset_env_uninserted(sample_u64()))
                     .collect()
             }
             Self::Thread(workers) => workers.reset_envs_uninserted(),

--- a/crates/r2l-sampler/src/direct/worker.rs
+++ b/crates/r2l-sampler/src/direct/worker.rs
@@ -6,10 +6,10 @@ use r2l_core::{
     buffers::{Memory, buffer::TrajectoryBuffer},
     env::{Env, EnvDescription, Snapshot},
     models::Actor,
-    rng::RNG,
+    rng::{env_seed, env_worker_rng},
     tensor::R2lTensor,
 };
-use rand::RngExt;
+use rand::{RngExt, rngs::StdRng};
 
 use crate::direct::RolloutMode;
 
@@ -23,12 +23,12 @@ pub fn step_env<T: R2lTensor, E: Env<Tensor = T>>(
     env: &mut E,
     actor: &mut Box<dyn Actor<Tensor = T>>,
     last_state: Option<T>,
+    rng: &mut StdRng,
 ) -> Memory<T> {
     let state = if let Some(state) = last_state {
         state
     } else {
-        let seed = RNG.with_borrow_mut(|rng| rng.random::<u64>());
-        env.reset(seed).unwrap()
+        env.reset(rng.random::<u64>()).unwrap()
     };
     let action = actor.action(state.clone()).unwrap();
     let Snapshot {
@@ -39,8 +39,7 @@ pub fn step_env<T: R2lTensor, E: Env<Tensor = T>>(
     } = env.step(action.clone()).unwrap();
     let done = terminated || truncated;
     if done {
-        let seed = RNG.with_borrow_mut(|rng| rng.random::<u64>());
-        next_state = env.reset(seed).unwrap();
+        next_state = env.reset(rng.random::<u64>()).unwrap();
     }
     Memory {
         state,
@@ -127,15 +126,21 @@ pub struct Worker<E: Env> {
     pub buffer: ElementHandle<TrajectoryBuffer<E::Tensor>>,
     pub actor: Option<Box<dyn Actor<Tensor = E::Tensor>>>,
     pub last_state: Option<E::Tensor>,
+    env_rng: StdRng,
 }
 
 impl<E: Env> Worker<E> {
-    pub fn new(env: E, buffer: ElementHandle<TrajectoryBuffer<E::Tensor>>) -> Self {
+    pub fn new(
+        env: E,
+        buffer: ElementHandle<TrajectoryBuffer<E::Tensor>>,
+        worker_idx: usize,
+    ) -> Self {
         Self {
             env,
             buffer,
             actor: None,
             last_state: None,
+            env_rng: env_worker_rng(worker_idx),
         }
     }
 
@@ -164,7 +169,7 @@ impl<E: Env> Worker<E> {
                 let mut episodes = 0;
                 loop {
                     let last_state = self.last_state.take();
-                    let memory = step_env(&mut self.env, actor, last_state);
+                    let memory = step_env(&mut self.env, actor, last_state, &mut self.env_rng);
                     let terminates = memory.is_done();
                     self.last_state = Some(memory.next_state.clone());
                     buffer.push(memory);
@@ -179,7 +184,7 @@ impl<E: Env> Worker<E> {
             RolloutMode::StepBound { n_steps } => {
                 for _ in 0..n_steps {
                     let last_state = self.last_state.take();
-                    let memory = step_env(&mut self.env, actor, last_state);
+                    let memory = step_env(&mut self.env, actor, last_state, &mut self.env_rng);
                     self.last_state = Some(memory.next_state.clone());
                     buffer.push(memory);
                 }
@@ -301,8 +306,7 @@ impl<T: R2lTensor> ThreadWorkers<T> {
 
     pub fn reset_all(&self) {
         for worker_handle in self.worker_handles.iter() {
-            let seed = RNG.with_borrow_mut(|rng| rng.random::<u64>());
-            worker_handle.send(WorkerCommand::ResetEnv(seed));
+            worker_handle.send(WorkerCommand::ResetEnv(env_seed()));
         }
         for worker_handle in self.worker_handles.iter() {
             worker_handle.recv();
@@ -335,8 +339,7 @@ impl<T: R2lTensor> ThreadWorkers<T> {
 
     pub fn reset_envs_uninserted(&self) -> Vec<T> {
         for worker_handle in self.worker_handles.iter() {
-            let seed = RNG.with_borrow_mut(|rng| rng.random::<u64>());
-            worker_handle.send(WorkerCommand::ResetEnvUninserted(seed));
+            worker_handle.send(WorkerCommand::ResetEnvUninserted(env_seed()));
         }
         self.worker_handles
             .iter()
@@ -444,8 +447,7 @@ impl<E: Env> WorkerPool<E> {
         match self {
             Self::Vec(workers) => {
                 for worker in workers {
-                    let seed = RNG.with_borrow_mut(|rng| rng.random::<u64>());
-                    worker.reset(seed);
+                    worker.reset(env_seed());
                 }
             }
             Self::Thread(workers) => {
@@ -497,10 +499,7 @@ impl<E: Env> WorkerPool<E> {
                 // resets all the envs but does not set it as a last state
                 workers
                     .iter_mut()
-                    .map(|w| {
-                        let seed = RNG.with_borrow_mut(|rng| rng.random::<u64>());
-                        w.reset_env_uninserted(seed)
-                    })
+                    .map(|w| w.reset_env_uninserted(env_seed()))
                     .collect()
             }
             Self::Thread(workers) => workers.reset_envs_uninserted(),

--- a/crates/r2l-sampler/src/direct/worker.rs
+++ b/crates/r2l-sampler/src/direct/worker.rs
@@ -6,7 +6,7 @@ use r2l_core::{
     buffers::{Memory, buffer::TrajectoryBuffer},
     env::{Env, EnvDescription, Snapshot},
     models::Actor,
-    rng::{env_seed, env_worker_rng},
+    rng::{env_rng, env_seed},
     tensor::R2lTensor,
 };
 use rand::{RngExt, rngs::StdRng};
@@ -140,7 +140,7 @@ impl<E: Env> Worker<E> {
             buffer,
             actor: None,
             last_state: None,
-            env_rng: env_worker_rng(worker_idx),
+            env_rng: env_rng(worker_idx + 1),
         }
     }
 

--- a/crates/r2l-sampler/src/direct/worker.rs
+++ b/crates/r2l-sampler/src/direct/worker.rs
@@ -6,10 +6,9 @@ use r2l_core::{
     buffers::{Memory, buffer::TrajectoryBuffer},
     env::{Env, EnvDescription, Snapshot},
     models::Actor,
-    rng::{env_rng, env_seed},
+    rng::next_seed,
     tensor::R2lTensor,
 };
-use rand::{RngExt, rngs::StdRng};
 
 use crate::direct::RolloutMode;
 
@@ -23,12 +22,11 @@ pub fn step_env<T: R2lTensor, E: Env<Tensor = T>>(
     env: &mut E,
     actor: &mut Box<dyn Actor<Tensor = T>>,
     last_state: Option<T>,
-    rng: &mut StdRng,
 ) -> Memory<T> {
     let state = if let Some(state) = last_state {
         state
     } else {
-        env.reset(rng.random::<u64>()).unwrap()
+        env.reset(next_seed()).unwrap()
     };
     let action = actor.action(state.clone()).unwrap();
     let Snapshot {
@@ -39,7 +37,7 @@ pub fn step_env<T: R2lTensor, E: Env<Tensor = T>>(
     } = env.step(action.clone()).unwrap();
     let done = terminated || truncated;
     if done {
-        next_state = env.reset(rng.random::<u64>()).unwrap();
+        next_state = env.reset(next_seed()).unwrap();
     }
     Memory {
         state,
@@ -126,21 +124,15 @@ pub struct Worker<E: Env> {
     pub buffer: ElementHandle<TrajectoryBuffer<E::Tensor>>,
     pub actor: Option<Box<dyn Actor<Tensor = E::Tensor>>>,
     pub last_state: Option<E::Tensor>,
-    env_rng: StdRng,
 }
 
 impl<E: Env> Worker<E> {
-    pub fn new(
-        env: E,
-        buffer: ElementHandle<TrajectoryBuffer<E::Tensor>>,
-        worker_idx: usize,
-    ) -> Self {
+    pub fn new(env: E, buffer: ElementHandle<TrajectoryBuffer<E::Tensor>>) -> Self {
         Self {
             env,
             buffer,
             actor: None,
             last_state: None,
-            env_rng: env_rng(worker_idx + 1),
         }
     }
 
@@ -169,7 +161,7 @@ impl<E: Env> Worker<E> {
                 let mut episodes = 0;
                 loop {
                     let last_state = self.last_state.take();
-                    let memory = step_env(&mut self.env, actor, last_state, &mut self.env_rng);
+                    let memory = step_env(&mut self.env, actor, last_state);
                     let terminates = memory.is_done();
                     self.last_state = Some(memory.next_state.clone());
                     buffer.push(memory);
@@ -184,7 +176,7 @@ impl<E: Env> Worker<E> {
             RolloutMode::StepBound { n_steps } => {
                 for _ in 0..n_steps {
                     let last_state = self.last_state.take();
-                    let memory = step_env(&mut self.env, actor, last_state, &mut self.env_rng);
+                    let memory = step_env(&mut self.env, actor, last_state);
                     self.last_state = Some(memory.next_state.clone());
                     buffer.push(memory);
                 }
@@ -306,7 +298,7 @@ impl<T: R2lTensor> ThreadWorkers<T> {
 
     pub fn reset_all(&self) {
         for worker_handle in self.worker_handles.iter() {
-            worker_handle.send(WorkerCommand::ResetEnv(env_seed()));
+            worker_handle.send(WorkerCommand::ResetEnv(next_seed()));
         }
         for worker_handle in self.worker_handles.iter() {
             worker_handle.recv();
@@ -339,7 +331,7 @@ impl<T: R2lTensor> ThreadWorkers<T> {
 
     pub fn reset_envs_uninserted(&self) -> Vec<T> {
         for worker_handle in self.worker_handles.iter() {
-            worker_handle.send(WorkerCommand::ResetEnvUninserted(env_seed()));
+            worker_handle.send(WorkerCommand::ResetEnvUninserted(next_seed()));
         }
         self.worker_handles
             .iter()
@@ -447,7 +439,7 @@ impl<E: Env> WorkerPool<E> {
         match self {
             Self::Vec(workers) => {
                 for worker in workers {
-                    worker.reset(env_seed());
+                    worker.reset(next_seed());
                 }
             }
             Self::Thread(workers) => {
@@ -499,7 +491,7 @@ impl<E: Env> WorkerPool<E> {
                 // resets all the envs but does not set it as a last state
                 workers
                     .iter_mut()
-                    .map(|w| w.reset_env_uninserted(env_seed()))
+                    .map(|w| w.reset_env_uninserted(next_seed()))
                     .collect()
             }
             Self::Thread(workers) => workers.reset_envs_uninserted(),

--- a/crates/r2l-sampler/src/normalized/mod.rs
+++ b/crates/r2l-sampler/src/normalized/mod.rs
@@ -14,7 +14,7 @@ use r2l_core::{
     env::{Env, EnvBuilder, EnvBuilderType},
     models::Actor,
     on_policy::algorithm::Sampler,
-    rng::env_seed,
+    rng::next_seed,
     tensor::R2lTensor,
 };
 
@@ -83,7 +83,7 @@ impl<E: Env<Tensor: R2lTensor>> R2lNormalizedSamplerCore<E> {
         let mut envs_and_states = Vec::with_capacity(num_envs);
         for env_idx in 0..num_envs {
             let mut env = env_builder.build_idx(env_idx).unwrap();
-            let state = env.reset(env_seed()).unwrap();
+            let state = env.reset(next_seed()).unwrap();
             envs_and_states.push((env, state));
         }
         let initial_states = envs_and_states
@@ -111,7 +111,7 @@ impl<E: Env<Tensor: R2lTensor>> R2lNormalizedSamplerCore<E> {
                 worker_handles.push(ThreadHandle::new(command_tx, result_rx));
                 let env_builder = env_builder.clone();
                 let env_builder = move || env_builder.build_idx(idx);
-                ThreadWorkerFactory::new(command_rx, result_tx, env_builder.clone(), idx)
+                ThreadWorkerFactory::new(command_rx, result_tx, env_builder.clone(), next_seed())
             })
             .collect();
         let last_states = bimodal_array_with_factory(factories);

--- a/crates/r2l-sampler/src/normalized/mod.rs
+++ b/crates/r2l-sampler/src/normalized/mod.rs
@@ -14,7 +14,7 @@ use r2l_core::{
     env::{Env, EnvBuilder, EnvBuilderType},
     models::Actor,
     on_policy::algorithm::Sampler,
-    rng::next_seed,
+    rng::sample_u64,
     tensor::R2lTensor,
 };
 
@@ -83,7 +83,7 @@ impl<E: Env<Tensor: R2lTensor>> R2lNormalizedSamplerCore<E> {
         let mut envs_and_states = Vec::with_capacity(num_envs);
         for env_idx in 0..num_envs {
             let mut env = env_builder.build_idx(env_idx).unwrap();
-            let state = env.reset(next_seed()).unwrap();
+            let state = env.reset(sample_u64()).unwrap();
             envs_and_states.push((env, state));
         }
         let initial_states = envs_and_states
@@ -111,7 +111,7 @@ impl<E: Env<Tensor: R2lTensor>> R2lNormalizedSamplerCore<E> {
                 worker_handles.push(ThreadHandle::new(command_tx, result_rx));
                 let env_builder = env_builder.clone();
                 let env_builder = move || env_builder.build_idx(idx);
-                ThreadWorkerFactory::new(command_rx, result_tx, env_builder.clone(), next_seed())
+                ThreadWorkerFactory::new(command_rx, result_tx, env_builder.clone(), sample_u64())
             })
             .collect();
         let last_states = bimodal_array_with_factory(factories);

--- a/crates/r2l-sampler/src/normalized/mod.rs
+++ b/crates/r2l-sampler/src/normalized/mod.rs
@@ -14,10 +14,9 @@ use r2l_core::{
     env::{Env, EnvBuilder, EnvBuilderType},
     models::Actor,
     on_policy::algorithm::Sampler,
-    rng::RNG,
+    rng::env_seed,
     tensor::R2lTensor,
 };
-use rand::RngExt;
 
 use crate::{
     RolloutMode, SamplerExecutionMode, SamplerHookResult,
@@ -84,8 +83,7 @@ impl<E: Env<Tensor: R2lTensor>> R2lNormalizedSamplerCore<E> {
         let mut envs_and_states = Vec::with_capacity(num_envs);
         for env_idx in 0..num_envs {
             let mut env = env_builder.build_idx(env_idx).unwrap();
-            let seed = RNG.with_borrow_mut(|rng| rng.random::<u64>());
-            let state = env.reset(seed).unwrap();
+            let state = env.reset(env_seed()).unwrap();
             envs_and_states.push((env, state));
         }
         let initial_states = envs_and_states
@@ -113,7 +111,7 @@ impl<E: Env<Tensor: R2lTensor>> R2lNormalizedSamplerCore<E> {
                 worker_handles.push(ThreadHandle::new(command_tx, result_rx));
                 let env_builder = env_builder.clone();
                 let env_builder = move || env_builder.build_idx(idx);
-                ThreadWorkerFactory::new(command_rx, result_tx, env_builder.clone())
+                ThreadWorkerFactory::new(command_rx, result_tx, env_builder.clone(), idx)
             })
             .collect();
         let last_states = bimodal_array_with_factory(factories);

--- a/crates/r2l-sampler/src/normalized/worker.rs
+++ b/crates/r2l-sampler/src/normalized/worker.rs
@@ -4,10 +4,10 @@ use r2l_core::{
     buffers::{Memory, MultiMemory},
     env::{Env, EnvBuilder, Snapshot},
     models::Actor,
-    rng::RNG,
+    rng::env_worker_rng,
     tensor::R2lTensor,
 };
-use rand::RngExt;
+use rand::{RngExt, rngs::StdRng};
 
 pub enum WorkerCommand<T: R2lTensor> {
     Step,
@@ -26,11 +26,16 @@ pub enum WorkerResult<T: R2lTensor> {
 struct Worker<T: R2lTensor, E: Env<Tensor = T>> {
     actor: Option<Box<dyn Actor<Tensor = E::Tensor>>>,
     env: E,
+    env_rng: StdRng,
 }
 
 impl<T: R2lTensor, E: Env<Tensor = T>> Worker<T, E> {
-    fn new(env: E) -> Self {
-        Self { actor: None, env }
+    fn new(env: E, worker_idx: usize) -> Self {
+        Self {
+            actor: None,
+            env,
+            env_rng: env_worker_rng(worker_idx),
+        }
     }
 
     fn step(&mut self, handle: &mut ElementHandle<T>) -> Memory<T> {
@@ -47,8 +52,7 @@ impl<T: R2lTensor, E: Env<Tensor = T>> Worker<T, E> {
         } = self.env.step(action.clone()).unwrap();
         let done = terminated || truncated;
         if done {
-            let seed = RNG.with_borrow_mut(|rng| rng.random::<u64>());
-            next_state = self.env.reset(seed).unwrap();
+            next_state = self.env.reset(self.env_rng.random::<u64>()).unwrap();
         }
         *handle.lock().unwrap() = next_state.clone();
         Memory {
@@ -68,9 +72,9 @@ struct VecWorker<T: R2lTensor, E: Env<Tensor = T>> {
 }
 
 impl<T: R2lTensor, E: Env<Tensor = T>> VecWorker<T, E> {
-    fn new(env: E, handle: ElementHandle<T>) -> Self {
+    fn new(env: E, handle: ElementHandle<T>, worker_idx: usize) -> Self {
         Self {
-            worker: Worker::new(env),
+            worker: Worker::new(env, worker_idx),
             handle,
         }
     }
@@ -98,7 +102,8 @@ impl<T: R2lTensor, E: Env<Tensor = T>> VecWorkers<T, E> {
     pub fn new(workers: Vec<(E, ElementHandle<T>)>) -> Self {
         let workers = workers
             .into_iter()
-            .map(|(env, handle)| VecWorker::new(env, handle))
+            .enumerate()
+            .map(|(idx, (env, handle))| VecWorker::new(env, handle, idx))
             .collect();
         Self { workers }
     }
@@ -139,9 +144,14 @@ pub struct ThreadWorker<T: R2lTensor, E: Env<Tensor = T>> {
 }
 
 impl<T: R2lTensor, E: Env<Tensor = T>> ThreadWorker<T, E> {
-    fn new(env: E, rx: Receiver<WorkerCommand<T>>, tx: Sender<WorkerResult<T>>) -> Self {
+    fn new(
+        env: E,
+        rx: Receiver<WorkerCommand<T>>,
+        tx: Sender<WorkerResult<T>>,
+        worker_idx: usize,
+    ) -> Self {
         Self {
-            worker: Worker::new(env),
+            worker: Worker::new(env, worker_idx),
             rx,
             tx,
         }
@@ -152,8 +162,10 @@ impl<T: R2lTensor, E: Env<Tensor = T>> ElementWorker for ThreadWorker<T, E> {
     type T = T;
 
     fn build(&mut self) -> Self::T {
-        let seed = RNG.with_borrow_mut(|rng| rng.random::<u64>());
-        self.worker.env.reset(seed).unwrap()
+        self.worker
+            .env
+            .reset(self.worker.env_rng.random::<u64>())
+            .unwrap()
     }
 
     fn work(&mut self, mut handle: ElementHandle<Self::T>) {
@@ -185,6 +197,7 @@ pub struct ThreadWorkerFactory<T: R2lTensor, EB: EnvBuilder<Env: Env<Tensor = T>
     rx: Receiver<WorkerCommand<T>>,
     tx: Sender<WorkerResult<T>>,
     env_builder: EB,
+    worker_idx: usize,
 }
 
 impl<T: R2lTensor, EB: EnvBuilder<Env: Env<Tensor = T>>> ThreadWorkerFactory<T, EB> {
@@ -192,11 +205,13 @@ impl<T: R2lTensor, EB: EnvBuilder<Env: Env<Tensor = T>>> ThreadWorkerFactory<T, 
         rx: Receiver<WorkerCommand<T>>,
         tx: Sender<WorkerResult<T>>,
         env_builder: EB,
+        worker_idx: usize,
     ) -> Self {
         Self {
             rx,
             tx,
             env_builder,
+            worker_idx,
         }
     }
 }
@@ -208,7 +223,7 @@ impl<T: R2lTensor, EB: EnvBuilder<Env: Env<Tensor = T>>> ElementWorkerFactory
 
     fn build(self) -> Self::Worker {
         let env = self.env_builder.build_env().unwrap();
-        ThreadWorker::new(env, self.rx, self.tx)
+        ThreadWorker::new(env, self.rx, self.tx, self.worker_idx)
     }
 }
 

--- a/crates/r2l-sampler/src/normalized/worker.rs
+++ b/crates/r2l-sampler/src/normalized/worker.rs
@@ -4,7 +4,7 @@ use r2l_core::{
     buffers::{Memory, MultiMemory},
     env::{Env, EnvBuilder, Snapshot},
     models::Actor,
-    rng::env_worker_rng,
+    rng::{env_rng, env_seed},
     tensor::R2lTensor,
 };
 use rand::{RngExt, rngs::StdRng};
@@ -34,7 +34,7 @@ impl<T: R2lTensor, E: Env<Tensor = T>> Worker<T, E> {
         Self {
             actor: None,
             env,
-            env_rng: env_worker_rng(worker_idx),
+            env_rng: env_rng(worker_idx + 1),
         }
     }
 
@@ -88,8 +88,11 @@ impl<T: R2lTensor, E: Env<Tensor = T>> VecWorker<T, E> {
     }
 
     fn reset(&mut self) {
-        let seed = RNG.with_borrow_mut(|rng| rng.random::<u64>());
-        let state = self.worker.env.reset(seed).unwrap();
+        let state = self
+            .worker
+            .env
+            .reset(self.worker.env_rng.random::<u64>())
+            .unwrap();
         *self.handle.lock().unwrap() = state;
     }
 }
@@ -299,8 +302,7 @@ impl<T: R2lTensor> ThreadWorkers<T> {
 
     fn reset_all(&self) {
         for worker_handle in &self.worker_handles {
-            let seed = RNG.with_borrow_mut(|rng| rng.random::<u64>());
-            worker_handle.send(WorkerCommand::ResetEnv(seed));
+            worker_handle.send(WorkerCommand::ResetEnv(env_seed()));
         }
         for worker_handle in &self.worker_handles {
             let WorkerResult::EnvReset = worker_handle.recv() else {

--- a/crates/r2l-sampler/src/normalized/worker.rs
+++ b/crates/r2l-sampler/src/normalized/worker.rs
@@ -4,10 +4,9 @@ use r2l_core::{
     buffers::{Memory, MultiMemory},
     env::{Env, EnvBuilder, Snapshot},
     models::Actor,
-    rng::{env_rng, env_seed},
+    rng::{next_seed, set_seed},
     tensor::R2lTensor,
 };
-use rand::{RngExt, rngs::StdRng};
 
 pub enum WorkerCommand<T: R2lTensor> {
     Step,
@@ -26,16 +25,11 @@ pub enum WorkerResult<T: R2lTensor> {
 struct Worker<T: R2lTensor, E: Env<Tensor = T>> {
     actor: Option<Box<dyn Actor<Tensor = E::Tensor>>>,
     env: E,
-    env_rng: StdRng,
 }
 
 impl<T: R2lTensor, E: Env<Tensor = T>> Worker<T, E> {
-    fn new(env: E, worker_idx: usize) -> Self {
-        Self {
-            actor: None,
-            env,
-            env_rng: env_rng(worker_idx + 1),
-        }
+    fn new(env: E) -> Self {
+        Self { actor: None, env }
     }
 
     fn step(&mut self, handle: &mut ElementHandle<T>) -> Memory<T> {
@@ -52,7 +46,7 @@ impl<T: R2lTensor, E: Env<Tensor = T>> Worker<T, E> {
         } = self.env.step(action.clone()).unwrap();
         let done = terminated || truncated;
         if done {
-            next_state = self.env.reset(self.env_rng.random::<u64>()).unwrap();
+            next_state = self.env.reset(next_seed()).unwrap();
         }
         *handle.lock().unwrap() = next_state.clone();
         Memory {
@@ -72,9 +66,9 @@ struct VecWorker<T: R2lTensor, E: Env<Tensor = T>> {
 }
 
 impl<T: R2lTensor, E: Env<Tensor = T>> VecWorker<T, E> {
-    fn new(env: E, handle: ElementHandle<T>, worker_idx: usize) -> Self {
+    fn new(env: E, handle: ElementHandle<T>) -> Self {
         Self {
-            worker: Worker::new(env, worker_idx),
+            worker: Worker::new(env),
             handle,
         }
     }
@@ -88,11 +82,7 @@ impl<T: R2lTensor, E: Env<Tensor = T>> VecWorker<T, E> {
     }
 
     fn reset(&mut self) {
-        let state = self
-            .worker
-            .env
-            .reset(self.worker.env_rng.random::<u64>())
-            .unwrap();
+        let state = self.worker.env.reset(next_seed()).unwrap();
         *self.handle.lock().unwrap() = state;
     }
 }
@@ -105,8 +95,7 @@ impl<T: R2lTensor, E: Env<Tensor = T>> VecWorkers<T, E> {
     pub fn new(workers: Vec<(E, ElementHandle<T>)>) -> Self {
         let workers = workers
             .into_iter()
-            .enumerate()
-            .map(|(idx, (env, handle))| VecWorker::new(env, handle, idx))
+            .map(|(env, handle)| VecWorker::new(env, handle))
             .collect();
         Self { workers }
     }
@@ -147,14 +136,9 @@ pub struct ThreadWorker<T: R2lTensor, E: Env<Tensor = T>> {
 }
 
 impl<T: R2lTensor, E: Env<Tensor = T>> ThreadWorker<T, E> {
-    fn new(
-        env: E,
-        rx: Receiver<WorkerCommand<T>>,
-        tx: Sender<WorkerResult<T>>,
-        worker_idx: usize,
-    ) -> Self {
+    fn new(env: E, rx: Receiver<WorkerCommand<T>>, tx: Sender<WorkerResult<T>>) -> Self {
         Self {
-            worker: Worker::new(env, worker_idx),
+            worker: Worker::new(env),
             rx,
             tx,
         }
@@ -165,10 +149,7 @@ impl<T: R2lTensor, E: Env<Tensor = T>> ElementWorker for ThreadWorker<T, E> {
     type T = T;
 
     fn build(&mut self) -> Self::T {
-        self.worker
-            .env
-            .reset(self.worker.env_rng.random::<u64>())
-            .unwrap()
+        self.worker.env.reset(next_seed()).unwrap()
     }
 
     fn work(&mut self, mut handle: ElementHandle<Self::T>) {
@@ -200,7 +181,7 @@ pub struct ThreadWorkerFactory<T: R2lTensor, EB: EnvBuilder<Env: Env<Tensor = T>
     rx: Receiver<WorkerCommand<T>>,
     tx: Sender<WorkerResult<T>>,
     env_builder: EB,
-    worker_idx: usize,
+    worker_seed: u64,
 }
 
 impl<T: R2lTensor, EB: EnvBuilder<Env: Env<Tensor = T>>> ThreadWorkerFactory<T, EB> {
@@ -208,13 +189,13 @@ impl<T: R2lTensor, EB: EnvBuilder<Env: Env<Tensor = T>>> ThreadWorkerFactory<T, 
         rx: Receiver<WorkerCommand<T>>,
         tx: Sender<WorkerResult<T>>,
         env_builder: EB,
-        worker_idx: usize,
+        worker_seed: u64,
     ) -> Self {
         Self {
             rx,
             tx,
             env_builder,
-            worker_idx,
+            worker_seed,
         }
     }
 }
@@ -225,8 +206,9 @@ impl<T: R2lTensor, EB: EnvBuilder<Env: Env<Tensor = T>>> ElementWorkerFactory
     type Worker = ThreadWorker<T, <EB as EnvBuilder>::Env>;
 
     fn build(self) -> Self::Worker {
+        set_seed(self.worker_seed);
         let env = self.env_builder.build_env().unwrap();
-        ThreadWorker::new(env, self.rx, self.tx, self.worker_idx)
+        ThreadWorker::new(env, self.rx, self.tx)
     }
 }
 
@@ -302,7 +284,7 @@ impl<T: R2lTensor> ThreadWorkers<T> {
 
     fn reset_all(&self) {
         for worker_handle in &self.worker_handles {
-            worker_handle.send(WorkerCommand::ResetEnv(env_seed()));
+            worker_handle.send(WorkerCommand::ResetEnv(next_seed()));
         }
         for worker_handle in &self.worker_handles {
             let WorkerResult::EnvReset = worker_handle.recv() else {

--- a/crates/r2l-sampler/src/normalized/worker.rs
+++ b/crates/r2l-sampler/src/normalized/worker.rs
@@ -4,7 +4,7 @@ use r2l_core::{
     buffers::{Memory, MultiMemory},
     env::{Env, EnvBuilder, Snapshot},
     models::Actor,
-    rng::{next_seed, set_seed},
+    rng::{sample_u64, set_seed},
     tensor::R2lTensor,
 };
 
@@ -46,7 +46,7 @@ impl<T: R2lTensor, E: Env<Tensor = T>> Worker<T, E> {
         } = self.env.step(action.clone()).unwrap();
         let done = terminated || truncated;
         if done {
-            next_state = self.env.reset(next_seed()).unwrap();
+            next_state = self.env.reset(sample_u64()).unwrap();
         }
         *handle.lock().unwrap() = next_state.clone();
         Memory {
@@ -82,7 +82,7 @@ impl<T: R2lTensor, E: Env<Tensor = T>> VecWorker<T, E> {
     }
 
     fn reset(&mut self) {
-        let state = self.worker.env.reset(next_seed()).unwrap();
+        let state = self.worker.env.reset(sample_u64()).unwrap();
         *self.handle.lock().unwrap() = state;
     }
 }
@@ -149,7 +149,7 @@ impl<T: R2lTensor, E: Env<Tensor = T>> ElementWorker for ThreadWorker<T, E> {
     type T = T;
 
     fn build(&mut self) -> Self::T {
-        self.worker.env.reset(next_seed()).unwrap()
+        self.worker.env.reset(sample_u64()).unwrap()
     }
 
     fn work(&mut self, mut handle: ElementHandle<Self::T>) {
@@ -284,7 +284,7 @@ impl<T: R2lTensor> ThreadWorkers<T> {
 
     fn reset_all(&self) {
         for worker_handle in &self.worker_handles {
-            worker_handle.send(WorkerCommand::ResetEnv(next_seed()));
+            worker_handle.send(WorkerCommand::ResetEnv(sample_u64()));
         }
         for worker_handle in &self.worker_handles {
             let WorkerResult::EnvReset = worker_handle.recv() else {


### PR DESCRIPTION
We use splitmix for real random u64 seeds, the hexadecimal numbers are not random, those are known and good for u64 seeding, bit shifting isn't random either, it shifts the higher bits lower. Thread scheduling wont affect the seeds of the workers.
We need different env and policy RNG so for example different eval freq doesn't affect the seed stream. For candle the backend seeding is not implemented yet, but every other part of the run still seeds the same.